### PR TITLE
ESACPE-1396 -- moved from 0.7.2 to ghcr 0.9.11 due to the unavailability of base image + minor improvements

### DIFF
--- a/template/python3-fastapi-conda/Dockerfile
+++ b/template/python3-fastapi-conda/Dockerfile
@@ -25,7 +25,7 @@ ADD function/environment.yml /tmp/environment.yml
 
 # Install basic commands and mamba
 RUN apt-get update                                                                                                          && \
-    apt-get install -y ca-certificates wget bash bzip2                                                                      && \
+    apt-get install --no-install-recommends -y ca-certificates wget bash bzip2                                                                      && \
     wget -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba --strip-components=1 && \
     ./micromamba shell init -s bash -p ~/micromamba                                                                         && \
     apt-get clean autoremove --yes                                                                                          && \

--- a/template/python3-fastapi-conda/Dockerfile
+++ b/template/python3-fastapi-conda/Dockerfile
@@ -1,4 +1,5 @@
-FROM openfaas/of-watchdog:0.7.2 as watchdog
+FROM ghcr.io/openfaas/of-watchdog:0.9.11 as watchdog 
+
 FROM ubuntu:20.04
 
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
@@ -24,8 +25,8 @@ ADD function/environment.yml /tmp/environment.yml
 
 
 # Install basic commands and mamba
-RUN apt-get update                                                                                                          && \
-    apt-get install --no-install-recommends -y ca-certificates wget bash bzip2                                                                      && \
+RUN apt-get update -qy                                                                                                         && \
+    apt-get install -y --no-install-recommends ca-certificates wget bash bzip2                                                                      && \
     wget -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba --strip-components=1 && \
     ./micromamba shell init -s bash -p ~/micromamba                                                                         && \
     apt-get clean autoremove --yes                                                                                          && \


### PR DESCRIPTION
ESACPE-1396 -- moved from 0.7.2 to ghcr 0.9.11 due to the unavailability of base image + minor improvements

Local build ok:
(base) mlongobardo@Micheles-MacBook-Pro python3-fastapi-conda % docker build -t python3-fastapi-conda-template .
Sending build context to Docker daemon 8.071MB
Step 1/14 : FROM ghcr.io/openfaas/of-watchdog:0.9.11 as watchdog
---> e6296fe525cf
Step 2/14 : FROM ubuntu:20.04
---> d5447fc01ae6
Step 3/14 : COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
---> Using cache
---> 7af9f5d52925
.
.
.
Successfully built 776e5206f671
Successfully tagged python3-fastapi-conda-template:latest