### PR TITLE
Update Dockerfile for ESACPE-1823

### DIFF
--- a/template/python3-fastapi-conda/Dockerfile
+++ b/template/python3-fastapi-conda/Dockerfile
@@ -1,6 +1,7 @@
 FROM ghcr.io/openfaas/of-watchdog:0.9.11 as watchdog 
 
-FROM ubuntu:20.04
+#points to last lts
+FROM ubuntu:latest
 
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
 
@@ -35,8 +36,12 @@ RUN apt-get update -qy                                                          
     rm -fr /srv/conda/pkgs                                                                                                  && \
     rm -fr /tmp/*
 
+#For opensearch-client
+RUN wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.0g-2ubuntu4_amd64.deb && \
+    dpkg -i libssl1.1_1.1.0g-2ubuntu4_amd64.deb
 
 USER app
+ENV LD_LIBRARY_PATH=/usr/local/ssl/lib:$LD_LIBRARY_PATH
 
 COPY --chown=app:app index.py  /home/app/index.py
 


### PR DESCRIPTION
Build and run logs

base) mlongobardo@Micheles-MacBook-Pro python3-fastapi-conda % docker build -t faas-template . [+] Building 178.2s (19/19) FINISHED
=> [internal] load build definition from Dockerfile 0.0s => => transferring dockerfile: 3.41kB 0.0s
=> [internal] load .dockerignore 0.0s
=> => transferring context: 2B 0.0s
=> [internal] load metadata for ghcr.io/openfaas/of-watchdog:0.9.11 2.4s => [internal] load metadata for docker.io/library/ubuntu:latest 5.0s => [internal] load build context 0.0s
=> => transferring context: 213B 0.0s
=> CACHED [watchdog 1/1] FROM ghcr.io/openfaas/of-watchdog:0.9.11@sha256:b84fd6db48e31e3d65dcd36672bf49b7a7b3dfced49ce602f51e877d9d1d56e4 0.0s => CACHED FROM docker.io/mambaorg/micromamba:alpine 2.9s => => resolve docker.io/mambaorg/micromamba:alpine 2.9s => [stage-1 1/11] FROM docker.io/library/ubuntu:latest@sha256:77906da86b60585ce12215807090eb327e7386c8fafb5402369e421f44eff17e 2.1s => => resolve docker.io/library/ubuntu:latest@sha256:77906da86b60585ce12215807090eb327e7386c8fafb5402369e421f44eff17e 0.0s => => sha256:ca2b0f26964cf2e80ba3e084d5983dab293fdb87485dc6445f3f7bbfc89d7459 2.30kB / 2.30kB 0.0s => => sha256:bccd10f490ab0f3fba61b193d1b80af91b17ca9bdca9768a16ed05ce16552fcb 29.54MB / 29.54MB 1.2s => => sha256:77906da86b60585ce12215807090eb327e7386c8fafb5402369e421f44eff17e 1.13kB / 1.13kB 0.0s => => sha256:aa772c98400ef833586d1d517d3e8de670f7e712bf581ce6053165081773259d 424B / 424B 0.0s => => extracting sha256:bccd10f490ab0f3fba61b193d1b80af91b17ca9bdca9768a16ed05ce16552fcb 0.7s => [stage-1 2/11] COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog 0.1s => [stage-1 3/11] RUN chmod +x /usr/bin/fwatchdog && groupadd --gid 1002 app && useradd --comment " 0.6s => [stage-1 4/11] ADD function/environment.yml /tmp/environment.yml 0.0s => [stage-1 5/11] COPY --from=docker.io/mambaorg/micromamba:alpine /bin/micromamba /bin/micromamba 0.1s => [stage-1 6/11] RUN apt-get update -qy && apt-get install -y --no-install-recommends ca-certificates wget 165.2s => [stage-1 7/11] RUN wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.0g-2ubuntu4_amd64.deb && dpkg -i libssl1.1_1.1.0g-2ubuntu4_amd64.deb 3.4s => [stage-1 8/11] COPY --chown=app:app index.py /home/app/index.py 0.0s => [stage-1 9/11] RUN mkdir -p /home/app/function && touch /home/app/function/__init__.py 0.5s => [stage-1 10/11] COPY --chown=app:app function /home/app/function 0.0s => [stage-1 11/11] WORKDIR /home/app/ 0.0s
=> exporting to image 1.1s
=> => exporting layers 1.1s
=> => writing image sha256:751281883141aaa85b1ce0a53bfd3e3a2a8e9dfedb5ed1a1a5649f6606466ccb 0.0s => => naming to docker.io/library/faas-template
--

env_openfaas) root@ea443baf7187:/home/app# ls -lart /var/lib/dpkg/info/libssl1.1* -rw-r--r-- 1 root root 74 Apr 25 2018 /var/lib/dpkg/info/libssl1.1:amd64.triggers -rw-r--r-- 1 root root 33399 Apr 25 2018 /var/lib/dpkg/info/libssl1.1:amd64.templates -rw-r--r-- 1 root root 181328 Apr 25 2018 /var/lib/dpkg/info/libssl1.1:amd64.symbols -rw-r--r-- 1 root root 163 Apr 25 2018 /var/lib/dpkg/info/libssl1.1:amd64.shlibs -rwxr-xr-x 1 root root 220 Apr 25 2018 /var/lib/dpkg/info/libssl1.1:amd64.postrm -rwxr-xr-x 1 root root 7815 Apr 25 2018 /var/lib/dpkg/info/libssl1.1:amd64.postinst -rw-r--r-- 1 root root 529 Apr 25 2018 /var/lib/dpkg/info/libssl1.1:amd64.md5sums -rw-r--r-- 1 root root 430 Mar 26 14:46 /var/lib/dpkg/info/libssl1.1:amd64.list (env_openfaas) root@ea443baf7187:/home/app# cat /etc/*release DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=22.04
DISTRIB_CODENAME=jammy
DISTRIB_DESCRIPTION="Ubuntu 22.04.4 LTS"
PRETTY_NAME="Ubuntu 22.04.4 LTS"
NAME="Ubuntu"
VERSION_ID="22.04"
VERSION="22.04.4 LTS (Jammy Jellyfish)"
VERSION_CODENAME=jammy
ID=ubuntu
ID_LIKE=debian
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/" PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy" UBUNTU_CODENAME=jammy
(base) mlongobardo@Micheles-MacBook-Pro python3-fastapi-conda % docker run -u root --rm -it faas-template bash root@ea443baf7187:/home/app# micromamba env list
Name Active Path
──────────────────────────────────────────────
base /root/micromamba
/srv/conda/envs/env_openfaas
root@ea443baf7187:/home/app# micromamba activate /srv/conda/envs/env_openfaas (env_openfaas) root@ea443baf7187:/home/app# micromamba install -c terradue opensearch-client terradue/noarch (check zst) Checked 1.5s
terradue/linux-64 (check zst) Checked 1.5s
terradue/noarch 5.6kB @ 15.3kB/s 0.4s
terradue/linux-64 30.0kB @ 66.1kB/s 0.5s

Pinned packages:
- python 3.12.*

Transaction

Prefix: /srv/conda/envs/env_openfaas

Updating specs:

- opensearch-client

Package Version Build Channel Size
────────────────────────────────────────────────────────── Install:
──────────────────────────────────────────────────────────

+ opensearch-client 2.0.1 0 terradue 35MB

Summary:

Install: 1 packages

Total download: 35MB

──────────────────────────────────────────────────────────

Confirm changes: [Y/n] y

Transaction starting
opensearch-client 34.6MB @ 12.3MB/s 2.8s
Linking opensearch-client-2.0.1-0

Transaction finished

To activate this environment, use:

micromamba activate /srv/conda/envs/env_openfaas

Or to execute a single command in this environment, use:

micromamba run -p /srv/conda/envs/env_openfaas mycommand

(env_openfaas) root@ea443baf7187:/home/app# uvicorn --help Usage: uvicorn [OPTIONS] APP

Options:
--host TEXT Bind socket to this host. [default:
127.0.0.1]
.
.
% docker exec -ti ea443baf7187 opensearch-client -p count=unlimited -m EOP -p 'cc=[25' -p start=2023-02-24T00:00:00Z -p 'geom=POLYGON((-45.771 -23.794,-45.771 -23.712,-45.614 -23.712,-45.614 -23.794,-45.771 -23.794))' -p 'cat=[chartercalibrateddataset,!excluded,{callid2120}]' -p 'q=call2120_S2*_MSIL2A_*T23KMP_*' https://catalog.mapper-dev.terradue.com/charter/search\
>

https://catalog.mapper-dev.terradue.com/charter/search?format=atom&uid=call2120_S2A_MSIL2A_20230312T131241_N0509_R138_T23KMP_20230312T191554-calibrated https://catalog.mapper-dev.terradue.com/charter/search?format=atom&uid=call2120_S2B_MSIL2A_20230307T131249_N0509_R138_T23KMP_20230307T170513-calibrated