### PR TITLE
Update Dockerfile to fix -p flag on micromamba (breaking change on the new micromamba) 

### DIFF
--- a/template/python3-fastapi-conda/Dockerfile
+++ b/template/python3-fastapi-conda/Dockerfile
@@ -22,7 +22,7 @@ ENV PATH=$PATH:/home/app/.local/bin:/srv/conda/envs/env_openfaas/bin            
     mode="http"                                                                         \
     upstream_url="http://127.0.0.1:8000"
 
-COPY  --from=docker.io/mambaorg/micromamba:alpine /bin/micromamba /bin/micromamba
+COPY  --from=docker.io/mambaorg/micromamba:1-alpine /bin/micromamba /bin/micromamba
 
 RUN mkdir -p /home/app/function                                                                                             && \
     touch /home/app/function/__init__.py                                                                                    && \


### PR DESCRIPTION
Log failure + fix : 

```
#17 44.61 The following argument was not expected: -p
#17 44.61 Run with --help for more information.
#17 ERROR: process "/bin/sh -c apt-get update -qy                                                                                                      &&     apt-get install -y --no-install-recommends ca-certificates wget bash bzip2                                              &&     micromamba shell init -s bash -p ~/micromamba                                                                           &&     apt-get clean autoremove --yes                                                                                          &&     rm -rf /var/lib/{apt,dpkg,cache,log}                                                                                    &&     chmod +x /usr/bin/micromamba                                                                                            &&     ls -la  &&  ls -la /home/app                                                                                            &&     micromamba create -f /home/app/environment.yml                                                                          &&     rm -fr /srv/conda/pkgs                                                                                                  &&     rm -fr /tmp/*" did not complete successfully: exit code: 109
------
 > [stage-1  9/11] RUN apt-get update -qy                                                                                                      &&     apt-get install -y --no-install-recommends ca-certificates wget bash bzip2                                              &&     micromamba shell init -s bash -p ~/micromamba                                                                           &&     apt-get clean autoremove --yes                                                                                          &&     rm -rf /var/lib/{apt,dpkg,cache,log}                                                                                    &&     chmod +x /usr/bin/micromamba                                                                                            &&     ls -la  &&  ls -la /home/app                                                                                            &&     micromamba create -f /home/app/environment.yml                                                                          &&     rm -fr /srv/conda/pkgs                                                                                                  &&     rm -fr /tmp/*:
26.27 Updating certificates in /etc/ssl/certs...
36.34 146 added, 0 removed; done.
36.44 Processing triggers for libc-bin (2.39-0ubuntu8.3) ...
36.51 Processing triggers for ca-certificates (20240203) ...
36.57 Updating certificates in /etc/ssl/certs...
44.35 0 added, 0 removed; done.
44.35 Running hooks in /etc/ca-certificates/update.d...
44.37 done.
44.61 The following argument was not expected: -p
44.61 Run with --help for more information.
------

 2 warnings found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
 - UndefinedVar: Usage of undefined variable '$LD_LIBRARY_PATH' (line 52)
Dockerfile:36
--------------------
  35 |     # Install basic commands and mamba
  36 | >>> RUN apt-get update -qy                                                                                                      && \
  37 | >>>     apt-get install -y --no-install-recommends ca-certificates wget bash bzip2                                              && \
  38 | >>>     micromamba shell init -s bash -p ~/micromamba                                                                           && \
  39 | >>>     apt-get clean autoremove --yes                                                                                          && \
  40 | >>>     rm -rf /var/lib/{apt,dpkg,cache,log}                                                                                    && \
  41 | >>>     chmod +x /usr/bin/micromamba                                                                                            && \
  42 | >>>     ls -la  &&  ls -la /home/app                                                                                            && \
  43 | >>>     micromamba create -f /home/app/environment.yml                                                                          && \                                                              
  44 | >>>     rm -fr /srv/conda/pkgs                                                                                                  && \
  45 | >>>     rm -fr /tmp/*
  46 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c apt-get update -qy                                                                                                      &&     apt-get install -y --no-install-recommends ca-certificates wget bash bzip2                                              &&     micromamba shell init -s bash -p ~/micromamba                                                                           &&     apt-get clean autoremove --yes                                                                                          &&     rm -rf /var/lib/{apt,dpkg,cache,log}                                                                                    &&     chmod +x /usr/bin/micromamba                                                                                            &&     ls -la  &&  ls -la /home/app                                                                                            &&     micromamba create -f /home/app/environment.yml                                                                          &&     rm -fr /srv/conda/pkgs                                                                                                  &&     rm -fr /tmp/*" did not complete successfully: exit code: 109

View build details: docker-desktop://dashboard/build/desktop-linux/desktop-linux/4j13t3b1qfepotrsgn5kh5l7z
[0] < Building sbas-assertion done in 54.12s.
[0] Worker done.

Total build time: 54.12s
Errors received during build:
- [sbas-assertion] received non-zero exit code from build, error: #0 building with "desktop-linux" instance using docker driver

#1 [internal] load build definition from Dockerfile
#1 transferring dockerfile: 3.64kB done
#1 WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
#1 DONE 0.0s

#2 [internal] load metadata for docker.io/mambaorg/micromamba:alpine
#2 DONE 0.0s

#3 [internal] load metadata for docker.io/library/ubuntu:latest
#3 ...

#4 [internal] load metadata for ghcr.io/openfaas/of-watchdog:0.9.11
#4 DONE 1.3s

#3 [internal] load metadata for docker.io/library/ubuntu:latest
#3 DONE 1.7s

#5 [internal] load .dockerignore
#5 transferring context: 2B done
#5 DONE 0.0s

#6 [internal] load build context
#6 transferring context: 85.00kB done
#6 DONE 0.0s

#7 FROM docker.io/mambaorg/micromamba:alpine
#7 DONE 0.1s

#8 [stage-1  1/11] FROM docker.io/library/ubuntu:latest@sha256:ab64a8382e935382638764d8719362bb50ee418d944c1f3d26e0c99fae49a345
#8 resolve docker.io/library/ubuntu:latest@sha256:ab64a8382e935382638764d8719362bb50ee418d944c1f3d26e0c99fae49a345 0.0s done
#8 sha256:08a4455a1f5a50a3dd22309df017cec827f352258596174f1cbbb7da990d1368 424B / 424B done
#8 sha256:dc4c1391d3701ce1105f6384632f71fd08abf4862c16f6612d74f262adc8665a 2.29kB / 2.29kB done
#8 sha256:d1fbec07a2e50e73803e0c9ea0fc8f9fb48ad1215583bb1bbb8852660f52abeb 0B / 29.75MB 0.2s
#8 sha256:ab64a8382e935382638764d8719362bb50ee418d944c1f3d26e0c99fae49a345 1.34kB / 1.34kB done
#8 sha256:d1fbec07a2e50e73803e0c9ea0fc8f9fb48ad1215583bb1bbb8852660f52abeb 2.10MB / 29.75MB 0.6s
#8 sha256:d1fbec07a2e50e73803e0c9ea0fc8f9fb48ad1215583bb1bbb8852660f52abeb 5.24MB / 29.75MB 1.1s
#8 sha256:d1fbec07a2e50e73803e0c9ea0fc8f9fb48ad1215583bb1bbb8852660f52abeb 8.39MB / 29.75MB 1.7s
#8 sha256:d1fbec07a2e50e73803e0c9ea0fc8f9fb48ad1215583bb1bbb8852660f52abeb 10.49MB / 29.75MB 2.2s
#8 sha256:d1fbec07a2e50e73803e0c9ea0fc8f9fb48ad1215583bb1bbb8852660f52abeb 12.58MB / 29.75MB 2.5s
#8 sha256:d1fbec07a2e50e73803e0c9ea0fc8f9fb48ad1215583bb1bbb8852660f52abeb 14.68MB / 29.75MB 3.0s
#8 sha256:d1fbec07a2e50e73803e0c9ea0fc8f9fb48ad1215583bb1bbb8852660f52abeb 16.78MB / 29.75MB 3.4s
#8 ...

#9 [watchdog 1/1] FROM ghcr.io/openfaas/of-watchdog:0.9.11@sha256:b84fd6db48e31e3d65dcd36672bf49b7a7b3dfced49ce602f51e877d9d1d56e4
#9 resolve ghcr.io/openfaas/of-watchdog:0.9.11@sha256:b84fd6db48e31e3d65dcd36672bf49b7a7b3dfced49ce602f51e877d9d1d56e4 0.0s done
#9 sha256:b84fd6db48e31e3d65dcd36672bf49b7a7b3dfced49ce602f51e877d9d1d56e4 2.38kB / 2.38kB done
#9 sha256:2791f098c4eb336743552b6f14d95de449ee05cb4f7cf14fb1ace32e88d027df 481B / 481B done
#9 sha256:e6296fe525cf18cc0c8b56dac5c19afb261f391bb0ced5534ecc838273149daf 1.21kB / 1.21kB done
#9 sha256:30286d512291a06791ea2c25a87b69cb6f016799b5e6a94b33f07d2dbcbda14f 3.58MB / 3.58MB 3.6s done
#9 extracting sha256:30286d512291a06791ea2c25a87b69cb6f016799b5e6a94b33f07d2dbcbda14f 0.0s done
#9 DONE 3.7s

#8 [stage-1  1/11] FROM docker.io/library/ubuntu:latest@sha256:ab64a8382e935382638764d8719362bb50ee418d944c1f3d26e0c99fae49a345
#8 sha256:d1fbec07a2e50e73803e0c9ea0fc8f9fb48ad1215583bb1bbb8852660f52abeb 18.87MB / 29.75MB 3.8s
#8 sha256:d1fbec07a2e50e73803e0c9ea0fc8f9fb48ad1215583bb1bbb8852660f52abeb 20.97MB / 29.75MB 4.1s
#8 sha256:d1fbec07a2e50e73803e0c9ea0fc8f9fb48ad1215583bb1bbb8852660f52abeb 23.07MB / 29.75MB 4.4s
#8 sha256:d1fbec07a2e50e73803e0c9ea0fc8f9fb48ad1215583bb1bbb8852660f52abeb 26.21MB / 29.75MB 4.8s
#8 sha256:d1fbec07a2e50e73803e0c9ea0fc8f9fb48ad1215583bb1bbb8852660f52abeb 28.31MB / 29.75MB 5.2s
#8 sha256:d1fbec07a2e50e73803e0c9ea0fc8f9fb48ad1215583bb1bbb8852660f52abeb 29.75MB / 29.75MB 5.3s done
#8 extracting sha256:d1fbec07a2e50e73803e0c9ea0fc8f9fb48ad1215583bb1bbb8852660f52abeb
#8 extracting sha256:d1fbec07a2e50e73803e0c9ea0fc8f9fb48ad1215583bb1bbb8852660f52abeb 0.8s done
#8 DONE 6.3s

#10 [stage-1  2/11] COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
#10 DONE 0.2s

#11 [stage-1  3/11] RUN chmod +x /usr/bin/fwatchdog                                                     &&     groupadd --gid 1002 app                                                         &&     useradd --comment "Default user"                                                       --create-home                                                                          --gid 1002                                                                             --no-log-init                                                                          --shell /bin/bash                                                                      --uid 1002 app                                                                  &&     chown app /home/app
#11 DONE 0.3s

#12 [stage-1  4/11] COPY  --from=docker.io/mambaorg/micromamba:alpine /bin/micromamba /bin/micromamba
#12 DONE 0.0s

#13 [stage-1  5/11] RUN mkdir -p /home/app/function                                                                                             &&     touch /home/app/function/__init__.py                                                                                    &&     chown -R app:app /home/app
#13 DONE 0.2s

#14 [stage-1  6/11] COPY --chown=app:app function/environment.yml /home/app/environment.yml
#14 DONE 0.0s

#15 [stage-1  7/11] COPY --chown=app:app function /home/app/function
#15 DONE 0.0s

#16 [stage-1  8/11] COPY --chown=app:app index.py  /home/app/index.py
#16 DONE 0.0s

#17 [stage-1  9/11] RUN apt-get update -qy                                                                                                      &&     apt-get install -y --no-install-recommends ca-certificates wget bash bzip2                                              &&     micromamba shell init -s bash -p ~/micromamba                                                                           &&     apt-get clean autoremove --yes                                                                                          &&     rm -rf /var/lib/{apt,dpkg,cache,log}                                                                                    &&     chmod +x /usr/bin/micromamba                                                                                            &&     ls -la  &&  ls -la /home/app                                                                                            &&     micromamba create -f /home/app/environment.yml                                                                          &&     rm -fr /srv/conda/pkgs                                                                                                  &&     rm -fr /tmp/*
#17 0.419 Get:1 http://archive.ubuntu.com/ubuntu noble InRelease [256 kB]
#17 0.455 Get:2 http://security.ubuntu.com/ubuntu noble-security InRelease [126 kB]
#17 0.645 Get:3 http://archive.ubuntu.com/ubuntu noble-updates InRelease [126 kB]
#17 0.707 Get:4 http://archive.ubuntu.com/ubuntu noble-backports InRelease [126 kB]
#17 1.260 Get:5 http://security.ubuntu.com/ubuntu noble-security/universe amd64 Packages [372 kB]
#17 1.439 Get:6 http://security.ubuntu.com/ubuntu noble-security/restricted amd64 Packages [446 kB]
#17 1.505 Get:7 http://security.ubuntu.com/ubuntu noble-security/multiverse amd64 Packages [13.7 kB]
#17 1.507 Get:8 http://security.ubuntu.com/ubuntu noble-security/main amd64 Packages [482 kB]
#17 1.856 Get:9 http://archive.ubuntu.com/ubuntu noble/universe amd64 Packages [19.3 MB]
#17 4.833 Get:10 http://archive.ubuntu.com/ubuntu noble/multiverse amd64 Packages [331 kB]
#17 4.886 Get:11 http://archive.ubuntu.com/ubuntu noble/restricted amd64 Packages [117 kB]
#17 4.904 Get:12 http://archive.ubuntu.com/ubuntu noble/main amd64 Packages [1808 kB]
#17 5.194 Get:13 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 Packages [695 kB]
#17 5.307 Get:14 http://archive.ubuntu.com/ubuntu noble-updates/multiverse amd64 Packages [18.2 kB]
#17 5.309 Get:15 http://archive.ubuntu.com/ubuntu noble-updates/restricted amd64 Packages [446 kB]
#17 5.381 Get:16 http://archive.ubuntu.com/ubuntu noble-updates/universe amd64 Packages [560 kB]
#17 5.479 Get:17 http://archive.ubuntu.com/ubuntu noble-backports/universe amd64 Packages [11.8 kB]
#17 7.937 Fetched 25.3 MB in 8s (3289 kB/s)
#17 7.937 Reading package lists...
#17 11.93 Reading package lists...
#17 15.83 Building dependency tree...
#17 16.45 Reading state information...
#17 17.14 bash is already the newest version (5.2.21-2ubuntu4).
#17 17.14 The following additional packages will be installed:
#17 17.14   libpsl5t64 openssl
#17 17.15 Suggested packages:
#17 17.15   bzip2-doc
#17 17.15 Recommended packages:
#17 17.15   publicsuffix
#17 17.26 The following NEW packages will be installed:
#17 17.26   bzip2 ca-certificates libpsl5t64 openssl wget
#17 17.48 0 upgraded, 5 newly installed, 0 to remove and 2 not upgraded.
#17 17.48 Need to get 1587 kB of archives.
#17 17.48 After this operation, 3476 kB of additional disk space will be used.
#17 17.48 Get:1 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 openssl amd64 3.0.13-0ubuntu3.4 [1003 kB]
#17 17.82 Get:2 http://archive.ubuntu.com/ubuntu noble/main amd64 ca-certificates all 20240203 [159 kB]
#17 17.85 Get:3 http://archive.ubuntu.com/ubuntu noble/main amd64 libpsl5t64 amd64 0.21.2-1.1build1 [57.1 kB]
#17 17.85 Get:4 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 wget amd64 1.21.4-1ubuntu4.1 [334 kB]
#17 17.90 Get:5 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 bzip2 amd64 1.0.8-5.1build0.1 [34.5 kB]
#17 18.42 debconf: delaying package configuration, since apt-utils is not installed
#17 18.52 Fetched 1587 kB in 1s (2677 kB/s)
#17 18.62 Selecting previously unselected package openssl.
(Reading database ... 4379 files and directories currently installed.)
#17 18.63 Preparing to unpack .../openssl_3.0.13-0ubuntu3.4_amd64.deb ...
#17 18.63 Unpacking openssl (3.0.13-0ubuntu3.4) ...
#17 18.78 Selecting previously unselected package ca-certificates.
#17 18.79 Preparing to unpack .../ca-certificates_20240203_all.deb ...
#17 18.79 Unpacking ca-certificates (20240203) ...
#17 18.95 Selecting previously unselected package libpsl5t64:amd64.
#17 18.95 Preparing to unpack .../libpsl5t64_0.21.2-1.1build1_amd64.deb ...
#17 18.95 Unpacking libpsl5t64:amd64 (0.21.2-1.1build1) ...
#17 19.06 Selecting previously unselected package wget.
#17 19.06 Preparing to unpack .../wget_1.21.4-1ubuntu4.1_amd64.deb ...
#17 19.06 Unpacking wget (1.21.4-1ubuntu4.1) ...
#17 19.17 Selecting previously unselected package bzip2.
#17 19.17 Preparing to unpack .../bzip2_1.0.8-5.1build0.1_amd64.deb ...
#17 19.17 Unpacking bzip2 (1.0.8-5.1build0.1) ...
#17 19.27 Setting up libpsl5t64:amd64 (0.21.2-1.1build1) ...
#17 19.28 Setting up bzip2 (1.0.8-5.1build0.1) ...
#17 19.28 Setting up openssl (3.0.13-0ubuntu3.4) ...
#17 19.31 Setting up wget (1.21.4-1ubuntu4.1) ...
#17 19.31 Setting up ca-certificates (20240203) ...
#17 19.86 debconf: unable to initialize frontend: Dialog
#17 19.86 debconf: (TERM is not set, so the dialog frontend is not usable.)
#17 19.86 debconf: falling back to frontend: Readline
#17 19.86 debconf: unable to initialize frontend: Readline
#17 19.86 debconf: (Can't locate Term/ReadLine.pm in @INC (you may need to install the Term::ReadLine module) (@INC entries checked: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.38.2 /usr/local/share/perl/5.38.2 /usr/lib/x86_64-linux-gnu/perl5/5.38 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl-base /usr/lib/x86_64-linux-gnu/perl/5.38 /usr/share/perl/5.38 /usr/local/lib/site_perl) at /usr/share/perl5/Debconf/FrontEnd/Readline.pm line 8.)
#17 19.86 debconf: falling back to frontend: Teletype
#17 26.27 Updating certificates in /etc/ssl/certs...
#17 36.34 146 added, 0 removed; done.
#17 36.44 Processing triggers for libc-bin (2.39-0ubuntu8.3) ...
#17 36.51 Processing triggers for ca-certificates (20240203) ...
#17 36.57 Updating certificates in /etc/ssl/certs...
#17 44.35 0 added, 0 removed; done.
#17 44.35 Running hooks in /etc/ca-certificates/update.d...
#17 44.37 done.
#17 44.61 The following argument was not expected: -p
#17 44.61 Run with --help for more information.
#17 ERROR: process "/bin/sh -c apt-get update -qy                                                                                                      &&     apt-get install -y --no-install-recommends ca-certificates wget bash bzip2                                              &&     micromamba shell init -s bash -p ~/micromamba                                                                           &&     apt-get clean autoremove --yes                                                                                          &&     rm -rf /var/lib/{apt,dpkg,cache,log}                                                                                    &&     chmod +x /usr/bin/micromamba                                                                                            &&     ls -la  &&  ls -la /home/app                                                                                            &&     micromamba create -f /home/app/environment.yml                                                                          &&     rm -fr /srv/conda/pkgs                                                                                                  &&     rm -fr /tmp/*" did not complete successfully: exit code: 109
------
 > [stage-1  9/11] RUN apt-get update -qy                                                                                                      &&     apt-get install -y --no-install-recommends ca-certificates wget bash bzip2                                              &&     micromamba shell init -s bash -p ~/micromamba                                                                           &&     apt-get clean autoremove --yes                                                                                          &&     rm -rf /var/lib/{apt,dpkg,cache,log}                                                                                    &&     chmod +x /usr/bin/micromamba                                                                                            &&     ls -la  &&  ls -la /home/app                                                                                            &&     micromamba create -f /home/app/environment.yml                                                                          &&     rm -fr /srv/conda/pkgs                                                                                                  &&     rm -fr /tmp/*:
26.27 Updating certificates in /etc/ssl/certs...
36.34 146 added, 0 removed; done.
36.44 Processing triggers for libc-bin (2.39-0ubuntu8.3) ...
36.51 Processing triggers for ca-certificates (20240203) ...
36.57 Updating certificates in /etc/ssl/certs...
44.35 0 added, 0 removed; done.
44.35 Running hooks in /etc/ca-certificates/update.d...
44.37 done.
44.61 The following argument was not expected: -p
44.61 Run with --help for more information.
------

 2 warnings found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
 - UndefinedVar: Usage of undefined variable '$LD_LIBRARY_PATH' (line 52)
Dockerfile:36
--------------------
  35 |     # Install basic commands and mamba
  36 | >>> RUN apt-get update -qy                                                                                                      && \
  37 | >>>     apt-get install -y --no-install-recommends ca-certificates wget bash bzip2                                              && \
  38 | >>>     micromamba shell init -s bash -p ~/micromamba                                                                           && \
  39 | >>>     apt-get clean autoremove --yes                                                                                          && \
  40 | >>>     rm -rf /var/lib/{apt,dpkg,cache,log}                                                                                    && \
  41 | >>>     chmod +x /usr/bin/micromamba                                                                                            && \
  42 | >>>     ls -la  &&  ls -la /home/app                                                                                            && \
  43 | >>>     micromamba create -f /home/app/environment.yml                                                                          && \                                                              
  44 | >>>     rm -fr /srv/conda/pkgs                                                                                                  && \
  45 | >>>     rm -fr /tmp/*
  46 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c apt-get update -qy                                                                                                      &&     apt-get install -y --no-install-recommends ca-certificates wget bash bzip2                                              &&     micromamba shell init -s bash -p ~/micromamba                                                                           &&     apt-get clean autoremove --yes                                                                                          &&     rm -rf /var/lib/{apt,dpkg,cache,log}                                                                                    &&     chmod +x /usr/bin/micromamba                                                                                            &&     ls -la  &&  ls -la /home/app                                                                                            &&     micromamba create -f /home/app/environment.yml                                                                          &&     rm -fr /srv/conda/pkgs                                                                                                  &&     rm -fr /tmp/*" did not complete successfully: exit code: 109

View build details: docker-desktop://dashboard/build/desktop-linux/desktop-linux/4j13t3b1qfepotrsgn5kh5l7z


(base) mlongobardo@Micheles-MBP p-sbas assertion % faas template pull --overwrite https://github.com/xmichele/openfaas-python3-fastapi-conda-template

Fetch templates from repository: https://github.com/xmichele/openfaas-python3-fastapi-conda-template at 
2024/10/15 10:45:57 Attempting to expand templates from https://github.com/xmichele/openfaas-python3-fastapi-conda-template
2024/10/15 10:45:57 Fetched 1 template(s) : [python3-fastapi-conda] from https://github.com/xmichele/openfaas-python3-fastapi-conda-template
(base) mlongobardo@Micheles-MBP p-sbas assertion % faas build -f sbas-assertion-dev.yml                                                              
[0] > Building sbas-assertion.
Clearing temporary build folder: ./build/sbas-assertion/
Preparing: ./sbas-assertion/ build/sbas-assertion/function
Building: cr.terradue.com/gep/sbas-assertion:dev with python3-fastapi-conda template. Please wait..
#0 building with "desktop-linux" instance using docker driver

#1 [internal] load build definition from Dockerfile
#1 transferring dockerfile: 3.64kB done
#1 WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
#1 DONE 0.0s

#2 [internal] load metadata for docker.io/mambaorg/micromamba:1-alpine
#2 DONE 0.0s

#3 [internal] load metadata for ghcr.io/openfaas/of-watchdog:0.9.11
#3 DONE 0.6s

#4 [internal] load metadata for docker.io/library/ubuntu:latest
#4 DONE 0.9s

#5 [internal] load .dockerignore
#5 transferring context: 2B done
#5 DONE 0.0s

#6 [watchdog 1/1] FROM ghcr.io/openfaas/of-watchdog:0.9.11@sha256:b84fd6db48e31e3d65dcd36672bf49b7a7b3dfced49ce602f51e877d9d1d56e4
#6 DONE 0.0s

#7 [stage-1  1/11] FROM docker.io/library/ubuntu:latest@sha256:ab64a8382e935382638764d8719362bb50ee418d944c1f3d26e0c99fae49a345
#7 DONE 0.0s

#8 [internal] load build context
#8 transferring context: 85.00kB done
#8 DONE 0.0s

#9 FROM docker.io/mambaorg/micromamba:1-alpine
#9 DONE 0.1s

#10 [stage-1  2/11] COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
#10 CACHED

#11 [stage-1  3/11] RUN chmod +x /usr/bin/fwatchdog                                                     &&     groupadd --gid 1002 app                                                         &&     useradd --comment "Default user"                                                       --create-home                                                                          --gid 1002                                                                             --no-log-init                                                                          --shell /bin/bash                                                                      --uid 1002 app                                                                  &&     chown app /home/app
#11 CACHED

#12 [stage-1  4/11] COPY  --from=docker.io/mambaorg/micromamba:1-alpine /bin/micromamba /bin/micromamba
#12 DONE 0.0s

#13 [stage-1  5/11] RUN mkdir -p /home/app/function                                                                                             &&     touch /home/app/function/__init__.py                                                                                    &&     chown -R app:app /home/app
#13 DONE 0.2s

#14 [stage-1  6/11] COPY --chown=app:app function/environment.yml /home/app/environment.yml
#14 DONE 0.0s

#15 [stage-1  7/11] COPY --chown=app:app function /home/app/function
#15 DONE 0.0s

#16 [stage-1  8/11] COPY --chown=app:app index.py  /home/app/index.py
#16 DONE 0.0s

#17 [stage-1  9/11] RUN apt-get update -qy                                                                                                      &&     apt-get install -y --no-install-recommends ca-certificates wget bash bzip2                                              &&     micromamba shell init -s bash -p ~/micromamba                                                                           &&     apt-get clean autoremove --yes                                                                                          &&     rm -rf /var/lib/{apt,dpkg,cache,log}                                                                                    &&     chmod +x /usr/bin/micromamba                                                                                            &&     ls -la  &&  ls -la /home/app                                                                                            &&     micromamba create -f /home/app/environment.yml                                                                          &&     rm -fr /srv/conda/pkgs                                                                                                  &&     rm -fr /tmp/*
#17 0.609 Get:1 http://archive.ubuntu.com/ubuntu noble InRelease [256 kB]
#17 0.626 Get:2 http://security.ubuntu.com/ubuntu noble-security InRelease [126 kB]
#17 1.217 Get:3 http://archive.ubuntu.com/ubuntu noble-updates InRelease [126 kB]
#17 1.379 Get:4 http://archive.ubuntu.com/ubuntu noble-backports InRelease [126 kB]
#17 1.769 Get:5 http://security.ubuntu.com/ubuntu noble-security/main amd64 Packages [482 kB]
#17 2.216 Get:6 http://security.ubuntu.com/ubuntu noble-security/restricted amd64 Packages [446 kB]
#17 2.269 Get:7 http://security.ubuntu.com/ubuntu noble-security/universe amd64 Packages [372 kB]
#17 2.337 Get:8 http://archive.ubuntu.com/ubuntu noble/restricted amd64 Packages [117 kB]
#17 2.366 Get:9 http://security.ubuntu.com/ubuntu noble-security/multiverse amd64 Packages [13.7 kB]
#17 2.493 Get:10 http://archive.ubuntu.com/ubuntu noble/multiverse amd64 Packages [331 kB]
#17 2.605 Get:11 http://archive.ubuntu.com/ubuntu noble/universe amd64 Packages [19.3 MB]
#17 5.828 Get:12 http://archive.ubuntu.com/ubuntu noble/main amd64 Packages [1808 kB]
#17 6.092 Get:13 http://archive.ubuntu.com/ubuntu noble-updates/multiverse amd64 Packages [18.2 kB]
#17 6.094 Get:14 http://archive.ubuntu.com/ubuntu noble-updates/restricted amd64 Packages [446 kB]
#17 6.161 Get:15 http://archive.ubuntu.com/ubuntu noble-updates/universe amd64 Packages [560 kB]
#17 6.246 Get:16 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 Packages [695 kB]
#17 6.350 Get:17 http://archive.ubuntu.com/ubuntu noble-backports/universe amd64 Packages [11.8 kB]
#17 9.024 Fetched 25.3 MB in 9s (2890 kB/s)
#17 9.024 Reading package lists...
#17 13.14 Reading package lists...
#17 17.27 Building dependency tree...
#17 17.92 Reading state information...
#17 18.52 bash is already the newest version (5.2.21-2ubuntu4).
#17 18.52 The following additional packages will be installed:
#17 18.53   libpsl5t64 openssl
#17 18.53 Suggested packages:
#17 18.53   bzip2-doc
#17 18.53 Recommended packages:
#17 18.53   publicsuffix
#17 18.64 The following NEW packages will be installed:
#17 18.64   bzip2 ca-certificates libpsl5t64 openssl wget
#17 18.98 0 upgraded, 5 newly installed, 0 to remove and 2 not upgraded.
#17 18.98 Need to get 1587 kB of archives.
#17 18.98 After this operation, 3476 kB of additional disk space will be used.
#17 18.98 Get:1 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 openssl amd64 3.0.13-0ubuntu3.4 [1003 kB]
#17 19.79 Get:2 http://archive.ubuntu.com/ubuntu noble/main amd64 ca-certificates all 20240203 [159 kB]
#17 19.80 Get:3 http://archive.ubuntu.com/ubuntu noble/main amd64 libpsl5t64 amd64 0.21.2-1.1build1 [57.1 kB]
#17 19.81 Get:4 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 wget amd64 1.21.4-1ubuntu4.1 [334 kB]
#17 19.86 Get:5 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 bzip2 amd64 1.0.8-5.1build0.1 [34.5 kB]
#17 20.34 debconf: delaying package configuration, since apt-utils is not installed
#17 20.42 Fetched 1587 kB in 1s (1344 kB/s)
#17 20.51 Selecting previously unselected package openssl.
(Reading database ... 4379 files and directories currently installed.)
#17 20.52 Preparing to unpack .../openssl_3.0.13-0ubuntu3.4_amd64.deb ...
#17 20.53 Unpacking openssl (3.0.13-0ubuntu3.4) ...
#17 20.66 Selecting previously unselected package ca-certificates.
#17 20.66 Preparing to unpack .../ca-certificates_20240203_all.deb ...
#17 20.66 Unpacking ca-certificates (20240203) ...
#17 20.78 Selecting previously unselected package libpsl5t64:amd64.
#17 20.78 Preparing to unpack .../libpsl5t64_0.21.2-1.1build1_amd64.deb ...
#17 20.79 Unpacking libpsl5t64:amd64 (0.21.2-1.1build1) ...
#17 20.89 Selecting previously unselected package wget.
#17 20.89 Preparing to unpack .../wget_1.21.4-1ubuntu4.1_amd64.deb ...
#17 20.89 Unpacking wget (1.21.4-1ubuntu4.1) ...
#17 20.99 Selecting previously unselected package bzip2.
#17 20.99 Preparing to unpack .../bzip2_1.0.8-5.1build0.1_amd64.deb ...
#17 20.99 Unpacking bzip2 (1.0.8-5.1build0.1) ...
#17 21.07 Setting up libpsl5t64:amd64 (0.21.2-1.1build1) ...
#17 21.08 Setting up bzip2 (1.0.8-5.1build0.1) ...
#17 21.09 Setting up openssl (3.0.13-0ubuntu3.4) ...
#17 21.11 Setting up wget (1.21.4-1ubuntu4.1) ...
#17 21.11 Setting up ca-certificates (20240203) ...
#17 21.62 debconf: unable to initialize frontend: Dialog
#17 21.62 debconf: (TERM is not set, so the dialog frontend is not usable.)
#17 21.62 debconf: falling back to frontend: Readline
#17 21.62 debconf: unable to initialize frontend: Readline
#17 21.62 debconf: (Can't locate Term/ReadLine.pm in @INC (you may need to install the Term::ReadLine module) (@INC entries checked: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.38.2 /usr/local/share/perl/5.38.2 /usr/lib/x86_64-linux-gnu/perl5/5.38 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl-base /usr/lib/x86_64-linux-gnu/perl/5.38 /usr/share/perl/5.38 /usr/local/lib/site_perl) at /usr/share/perl5/Debconf/FrontEnd/Readline.pm line 8.)
#17 21.62 debconf: falling back to frontend: Teletype
#17 27.52 Updating certificates in /etc/ssl/certs...
#17 37.84 146 added, 0 removed; done.
#17 37.95 Processing triggers for libc-bin (2.39-0ubuntu8.3) ...
#17 38.02 Processing triggers for ca-certificates (20240203) ...
#17 38.09 Updating certificates in /etc/ssl/certs...
#17 45.75 0 added, 0 removed; done.
#17 45.75 Running hooks in /etc/ca-certificates/update.d...
#17 45.77 done.
#17 46.03 Modifying RC file "/root/.bashrc"
#17 46.03 Generating config for root prefix "/root/micromamba"
#17 46.03 Setting mamba executable to: "/usr/bin/micromamba"
#17 46.03 Adding (or replacing) the following in your "/root/.bashrc" file
#17 46.03 
#17 46.03 # >>> mamba initialize >>>
#17 46.03 # !! Contents within this block are managed by 'mamba init' !!
#17 46.03 export MAMBA_EXE='/usr/bin/micromamba';
#17 46.03 export MAMBA_ROOT_PREFIX='/root/micromamba';
#17 46.03 __mamba_setup="$("$MAMBA_EXE" shell hook --shell bash --root-prefix "$MAMBA_ROOT_PREFIX" 2> /dev/null)"
#17 46.03 if [ $? -eq 0 ]; then
#17 46.03     eval "$__mamba_setup"
#17 46.03 else
#17 46.03     alias micromamba="$MAMBA_EXE"  # Fallback on help from mamba activate
#17 46.03 fi
#17 46.03 unset __mamba_setup
#17 46.03 # <<< mamba initialize <<<
#17 46.03 
#17 46.18 total 72
#17 46.18 drwxr-xr-x   1 root root 4096 Oct 15 08:46 .
#17 46.18 drwxr-xr-x   1 root root 4096 Oct 15 08:46 ..
#17 46.18 lrwxrwxrwx   1 root root    7 Apr 22 13:08 bin -> usr/bin
#17 46.18 drwxr-xr-x   2 root root 4096 Apr 22 13:08 boot
#17 46.18 drwxr-xr-x   5 root root  340 Oct 15 08:46 dev
#17 46.18 drwxr-xr-x   1 root root 4096 Oct 15 08:46 etc
#17 46.18 drwxr-xr-x   1 root root 4096 Oct 15 08:41 home
#17 46.18 lrwxrwxrwx   1 root root    7 Apr 22 13:08 lib -> usr/lib
#17 46.18 lrwxrwxrwx   1 root root    9 Apr 22 13:08 lib64 -> usr/lib64
#17 46.18 drwxr-xr-x   2 root root 4096 Oct  9 02:03 media
#17 46.18 drwxr-xr-x   2 root root 4096 Oct  9 02:03 mnt
#17 46.18 drwxr-xr-x   2 root root 4096 Oct  9 02:03 opt
#17 46.18 dr-xr-xr-x 216 root root    0 Oct 15 08:46 proc
#17 46.18 drwx------   1 root root 4096 Oct 15 08:46 root
#17 46.18 drwxr-xr-x   4 root root 4096 Oct  9 02:10 run
#17 46.18 lrwxrwxrwx   1 root root    8 Apr 22 13:08 sbin -> usr/sbin
#17 46.18 drwxr-xr-x   2 root root 4096 Oct  9 02:03 srv
#17 46.18 dr-xr-xr-x  11 root root    0 Oct 15 08:46 sys
#17 46.18 drwxrwxrwt   1 root root 4096 Oct 15 08:46 tmp
#17 46.18 drwxr-xr-x   1 root root 4096 Oct  9 02:03 usr
#17 46.18 drwxr-xr-x   1 root root 4096 Oct  9 02:09 var
#17 46.21 total 36
#17 46.21 drwxr-x--- 1 app  app  4096 Oct 15 08:46 .
#17 46.21 drwxr-xr-x 1 root root 4096 Oct 15 08:41 ..
#17 46.21 -rw-r--r-- 1 app  app   220 Mar 31  2024 .bash_logout
#17 46.21 -rw-r--r-- 1 app  app  3771 Mar 31  2024 .bashrc
#17 46.21 -rw-r--r-- 1 app  app   807 Mar 31  2024 .profile
#17 46.21 -rw-r--r-- 1 app  app   393 Oct 15 08:46 environment.yml
#17 46.21 drwxr-xr-x 1 app  app  4096 Oct 15 08:46 function
#17 46.21 -rw-r--r-- 1 app  app  3616 Oct 15 08:46 index.py
#17 154.5 
#17 154.5 Transaction
#17 154.5 
#17 154.5   Prefix: /srv/conda/envs/env_openfaas
#17 154.5 
#17 154.5   Updating specs:
#17 154.5 
#17 154.5    - python=3.9
#17 154.5    - pyproj
#17 154.5    - pystac
#17 154.5    - pystac-client
#17 154.5    - requests
#17 154.5    - shapely
#17 154.5    - pytz
#17 154.5    - fastapi
#17 154.5    - uvicorn
#17 154.5    - pandas
#17 154.5    - aiohttp
#17 154.5    - snuggs
#17 154.5    - pip
#17 154.5 
#17 154.5 
#17 154.6   Package                     Version  Build                Channel          Size
#17 154.6 ───────────────────────────────────────────────────────────────────────────────────
#17 154.6   Install:
#17 154.6 ───────────────────────────────────────────────────────────────────────────────────
#17 154.6 
#17 154.6   + python_abi                    3.9  5_cp39               conda-forge       6kB
#17 154.6   + _libgcc_mutex                 0.1  conda_forge          conda-forge       3kB
#17 154.6   + ld_impl_linux-64             2.43  h712a8e2_1           conda-forge     670kB
#17 154.6   + ca-certificates         2024.8.30  hbcca054_0           conda-forge     159kB
#17 154.6   + libgomp                    14.1.0  h77fa898_1           conda-forge     460kB
#17 154.6   + _openmp_mutex                 4.5  2_gnu                conda-forge      24kB
#17 154.6   + libgcc                     14.1.0  h77fa898_1           conda-forge     846kB
#17 154.6   + c-ares                     1.34.1  heb4867d_0           conda-forge     205kB
#17 154.6   + libgfortran5               14.1.0  hc5f4f2c_1           conda-forge       1MB
#17 154.6   + libuv                      1.49.1  hb9d3cd8_0           conda-forge     880kB
#17 154.6   + libdeflate                   1.22  hb9d3cd8_0           conda-forge      72kB
#17 154.6   + libzlib                     1.3.1  hb9d3cd8_2           conda-forge      61kB
#17 154.6   + libstdcxx                  14.1.0  hc0a3c3a_1           conda-forge       4MB
#17 154.6   + libgcc-ng                  14.1.0  h69a702a_1           conda-forge      52kB
#17 154.6   + openssl                     3.3.2  hb9d3cd8_0           conda-forge       3MB
#17 154.6   + libgfortran                14.1.0  h69a702a_1           conda-forge      52kB
#17 154.6   + libsqlite                  3.46.1  hadc24fc_0           conda-forge     865kB
#17 154.6   + libstdcxx-ng               14.1.0  h4852527_1           conda-forge      52kB
#17 154.6   + geos                       3.13.0  h5888daf_0           conda-forge       2MB
#17 154.6   + libev                        4.33  hd590300_2           conda-forge     113kB
#17 154.6   + libjpeg-turbo               3.0.0  hd590300_1           conda-forge     619kB
#17 154.6   + libwebp-base                1.4.0  hd590300_0           conda-forge     439kB
#17 154.6   + keyutils                    1.6.1  h166bdaf_0           conda-forge     118kB
#17 154.6   + tk                         8.6.13  noxft_h4845f30_101   conda-forge       3MB
#17 154.6   + libxcrypt                  4.4.36  hd590300_1           conda-forge     100kB
#17 154.6   + libffi                      3.4.2  h7f98852_5           conda-forge      58kB
#17 154.6   + bzip2                       1.0.8  h4bc722e_7           conda-forge     253kB
#17 154.6   + yaml                        0.2.5  h7f98852_2           conda-forge      89kB
#17 154.6   + ncurses                       6.5  he02047a_1           conda-forge     889kB
#17 154.6   + libuuid                    2.38.1  h0b41bf4_0           conda-forge      34kB
#17 154.6   + libnsl                      2.0.1  hd590300_0           conda-forge      33kB
#17 154.6   + xz                          5.2.6  h166bdaf_0           conda-forge     418kB
#17 154.6   + libssh2                    1.11.0  h0841786_0           conda-forge     271kB
#17 154.6   + libgfortran-ng             14.1.0  h69a702a_1           conda-forge      52kB
#17 154.6   + lerc                        4.0.0  h27087fc_0           conda-forge     282kB
#17 154.6   + zstd                        1.5.6  ha6fb4c9_0           conda-forge     555kB
#17 154.6   + libnghttp2                 1.58.0  h47da74e_1           conda-forge     632kB
#17 154.6   + libedit              3.1.20191231  he28a2e2_2           conda-forge     124kB
#17 154.6   + readline                      8.2  h8228510_1           conda-forge     281kB
#17 154.6   + libopenblas                0.3.27  pthreads_hac2b453_1  conda-forge       6MB
#17 154.6   + libtiff                     4.7.0  he137b08_1           conda-forge     428kB
#17 154.6   + krb5                       1.21.3  h659f571_0           conda-forge       1MB
#17 154.6   + sqlite                     3.46.1  h9eae976_0           conda-forge     859kB
#17 154.6   + libblas                     3.9.0  24_linux64_openblas  conda-forge      15kB
#17 154.6   + libcurl                    8.10.1  hbbe4b11_0           conda-forge     425kB
#17 154.6   + libcblas                    3.9.0  24_linux64_openblas  conda-forge      15kB
#17 154.6   + liblapack                   3.9.0  24_linux64_openblas  conda-forge      15kB
#17 154.6   + proj                        9.5.0  h12925eb_0           conda-forge       3MB
#17 154.6   + tzdata                      2024b  hc8b5060_0           conda-forge     122kB
#17 154.6   + python                     3.9.20  h13acc7a_1_cpython   conda-forge      24MB
#17 154.6   + wheel                      0.44.0  pyhd8ed1ab_0         conda-forge      59kB
#17 154.6   + setuptools                 75.1.0  pyhd8ed1ab_0         conda-forge     777kB
#17 154.6   + pip                          24.2  pyh8b19718_1         conda-forge       1MB
#17 154.6   + hyperframe                  6.0.1  pyhd8ed1ab_0         conda-forge      15kB
#17 154.6   + hpack                       4.0.0  pyh9f0ad1d_0         conda-forge      25kB
#17 154.6   + mdurl                       0.1.2  pyhd8ed1ab_0         conda-forge      15kB
#17 154.6   + pygments                   2.18.0  pyhd8ed1ab_0         conda-forge     879kB
#17 154.6   + shellingham                 1.5.4  pyhd8ed1ab_0         conda-forge      15kB
#17 154.6   + pycparser                    2.22  pyhd8ed1ab_0         conda-forge     105kB
#17 154.6   + exceptiongroup              1.2.2  pyhd8ed1ab_0         conda-forge      20kB
#17 154.6   + six                        1.16.0  pyh6c4a22f_0         conda-forge      14kB
#17 154.6   + pysocks                     1.7.1  pyha2e5f31_6         conda-forge      19kB
#17 154.6   + aiohappyeyeballs            2.4.3  pyhd8ed1ab_0         conda-forge      19kB
#17 154.6   + attrs                      24.2.0  pyh71513ae_0         conda-forge      56kB
#17 154.6   + python-tzdata              2024.2  pyhd8ed1ab_0         conda-forge     143kB
#17 154.6   + click                       8.1.7  unix_pyh707e725_0    conda-forge      84kB
#17 154.6   + python-dotenv               1.0.1  pyhd8ed1ab_0         conda-forge      24kB
#17 154.6   + sniffio                     1.3.1  pyhd8ed1ab_0         conda-forge      15kB
#17 154.6   + typing_extensions          4.12.2  pyha770c72_0         conda-forge      40kB
#17 154.6   + python-multipart           0.0.12  pyhff2d567_0         conda-forge      27kB
#17 154.6   + charset-normalizer          3.4.0  pyhd8ed1ab_0         conda-forge      47kB
#17 154.6   + idna                         3.10  pyhd8ed1ab_0         conda-forge      50kB
#17 154.6   + certifi                 2024.8.30  pyhd8ed1ab_0         conda-forge     164kB
#17 154.6   + pyparsing                   3.2.0  pyhd8ed1ab_1         conda-forge      92kB
#17 154.6   + pytz                       2024.2  pyhd8ed1ab_0         conda-forge     187kB
#17 154.6   + h2                          4.1.0  pyhd8ed1ab_0         conda-forge      47kB
#17 154.6   + markdown-it-py              3.0.0  pyhd8ed1ab_0         conda-forge      64kB
#17 154.6   + python-dateutil             2.9.0  pyhd8ed1ab_0         conda-forge     223kB
#17 154.6   + dnspython                   2.7.0  pyhff2d567_0         conda-forge     173kB
#17 154.6   + typer-slim                 0.12.5  pyhd8ed1ab_0         conda-forge      46kB
#17 154.6   + h11                        0.14.0  pyhd8ed1ab_0         conda-forge      48kB
#17 154.6   + typing-extensions          4.12.2  hd8ed1ab_0           conda-forge      10kB
#17 154.6   + anyio                       4.4.0  pyhd8ed1ab_0         conda-forge     104kB
#17 154.6   + rich                       13.9.2  pyhd8ed1ab_0         conda-forge     186kB
#17 154.6   + pystac                     1.10.1  pyhd8ed1ab_0         conda-forge     121kB
#17 154.6   + email-validator             2.2.0  pyhd8ed1ab_0         conda-forge      44kB
#17 154.6   + annotated-types             0.7.0  pyhd8ed1ab_0         conda-forge      18kB
#17 154.6   + async-timeout               4.0.3  pyhd8ed1ab_0         conda-forge      11kB
#17 154.6   + httpcore                    1.0.6  pyhd8ed1ab_0         conda-forge      46kB
#17 154.6   + starlette                  0.39.2  pyhd8ed1ab_0         conda-forge      59kB
#17 154.6   + typer-slim-standard        0.12.5  hd8ed1ab_0           conda-forge      47kB
#17 154.6   + email_validator             2.2.0  hd8ed1ab_0           conda-forge       7kB
#17 154.6   + httpx                      0.27.2  pyhd8ed1ab_0         conda-forge      65kB
#17 154.6   + typer                      0.12.5  pyhd8ed1ab_0         conda-forge      53kB
#17 154.6   + propcache                   0.2.0  py39h8cd3c5a_2       conda-forge      53kB
#17 154.6   + markupsafe                  3.0.1  py39h9399b63_1       conda-forge      23kB
#17 154.6   + brotli-python               1.1.0  py39hf88036b_2       conda-forge     349kB
#17 154.6   + frozenlist                  1.4.1  py39h8cd3c5a_1       conda-forge      60kB
#17 154.6   + websockets                   13.1  py39h8cd3c5a_0       conda-forge     184kB
#17 154.6   + uvloop                     0.20.0  py39h8cd3c5a_0       conda-forge     933kB
#17 154.6   + pyyaml                      6.0.2  py39h8cd3c5a_1       conda-forge     182kB
#17 154.6   + httptools                   0.6.1  py39h8cd3c5a_1       conda-forge      91kB
#17 154.6   + numpy                       2.0.2  py39h9cb892a_0       conda-forge       8MB
#17 154.6   + cffi                       1.17.1  py39h15c3d72_0       conda-forge     242kB
#17 154.6   + pyproj                      3.6.1  py39h306d449_10      conda-forge     536kB
#17 154.6   + uvicorn                    0.31.1  py39hf3d152e_0       conda-forge     102kB
#17 154.6   + multidict                   6.1.0  py39h8cd3c5a_0       conda-forge      58kB
#17 154.6   + pydantic-core              2.23.4  py39he612d8f_0       conda-forge       2MB
#17 154.6   + watchfiles                 0.24.0  py39he612d8f_1       conda-forge     391kB
#17 154.6   + pandas                      2.2.2  py39hfc16268_1       conda-forge      13MB
#17 154.6   + shapely                     2.0.6  py39hca88cd1_2       conda-forge     487kB
#17 154.6   + zstandard                  0.23.0  py39h08a7858_1       conda-forge     407kB
#17 154.6   + yarl                       1.15.2  py39h8cd3c5a_0       conda-forge     130kB
#17 154.6   + uvicorn-standard           0.31.1  hf3d152e_0           conda-forge       7kB
#17 154.6   + jinja2                      3.1.4  pyhd8ed1ab_0         conda-forge     112kB
#17 154.6   + aiosignal                   1.3.1  pyhd8ed1ab_0         conda-forge      13kB
#17 154.6   + snuggs                      1.4.7  pyhd8ed1ab_1         conda-forge      11kB
#17 154.6   + pydantic                    2.9.2  pyhd8ed1ab_0         conda-forge     301kB
#17 154.6   + urllib3                     2.2.3  pyhd8ed1ab_0         conda-forge      98kB
#17 154.6   + fastapi-cli                 0.0.5  pyhd8ed1ab_1         conda-forge      14kB
#17 154.6   + requests                   2.32.3  pyhd8ed1ab_0         conda-forge      59kB
#17 154.6   + fastapi                   0.115.2  pyhd8ed1ab_0         conda-forge      73kB
#17 154.6   + pystac-client               0.8.3  pyhd8ed1ab_0         conda-forge      32kB
#17 154.6   + aiohttp                   3.10.10  py39h9399b63_0       conda-forge     721kB
#17 154.6 
#17 154.6   Summary:
#17 154.6 
#17 154.6   Install: 124 packages
#17 154.6 
#17 154.6   Total download: 92MB
#17 154.6 
#17 154.6 ───────────────────────────────────────────────────────────────────────────────────
#17 154.6 
#17 154.6 
#17 154.6 Confirm changes: [Y/n] 
#17 154.6 Transaction starting
#17 171.7 Linking python_abi-3.9-5_cp39
#17 171.7 Linking _libgcc_mutex-0.1-conda_forge
#17 171.7 Linking ld_impl_linux-64-2.43-h712a8e2_1
#17 171.7 Linking ca-certificates-2024.8.30-hbcca054_0
#17 171.7 Linking libgomp-14.1.0-h77fa898_1
#17 171.7 Linking _openmp_mutex-4.5-2_gnu
#17 171.7 Linking libgcc-14.1.0-h77fa898_1
#17 171.8 Linking c-ares-1.34.1-heb4867d_0
#17 171.8 Linking libgfortran5-14.1.0-hc5f4f2c_1
#17 171.8 Linking libuv-1.49.1-hb9d3cd8_0
#17 171.8 Linking libdeflate-1.22-hb9d3cd8_0
#17 171.8 Linking libzlib-1.3.1-hb9d3cd8_2
#17 171.8 Linking libstdcxx-14.1.0-hc0a3c3a_1
#17 171.8 Linking libgcc-ng-14.1.0-h69a702a_1
#17 171.8 Linking openssl-3.3.2-hb9d3cd8_0
#17 172.0 Linking libgfortran-14.1.0-h69a702a_1
#17 172.0 Linking libsqlite-3.46.1-hadc24fc_0
#17 172.1 Linking libstdcxx-ng-14.1.0-h4852527_1
#17 172.1 Linking geos-3.13.0-h5888daf_0
#17 172.2 Linking libev-4.33-hd590300_2
#17 172.2 Linking libjpeg-turbo-3.0.0-hd590300_1
#17 172.3 Linking libwebp-base-1.4.0-hd590300_0
#17 172.3 Linking keyutils-1.6.1-h166bdaf_0
#17 172.3 Linking tk-8.6.13-noxft_h4845f30_101
#17 172.5 Linking libxcrypt-4.4.36-hd590300_1
#17 172.5 Linking libffi-3.4.2-h7f98852_5
#17 172.5 Linking bzip2-1.0.8-h4bc722e_7
#17 172.5 Linking yaml-0.2.5-h7f98852_2
#17 172.5 Linking ncurses-6.5-he02047a_1
#17 190.3 Linking libuuid-2.38.1-h0b41bf4_0
#17 190.3 Linking libnsl-2.0.1-hd590300_0
#17 190.3 Linking xz-5.2.6-h166bdaf_0
#17 190.5 Linking libssh2-1.11.0-h0841786_0
#17 190.6 Linking libgfortran-ng-14.1.0-h69a702a_1
#17 190.6 Linking lerc-4.0.0-h27087fc_0
#17 190.6 Linking zstd-1.5.6-ha6fb4c9_0
#17 190.6 Linking libnghttp2-1.58.0-h47da74e_1
#17 190.7 Linking libedit-3.1.20191231-he28a2e2_2
#17 190.7 Linking readline-8.2-h8228510_1
#17 190.7 Linking libopenblas-0.3.27-pthreads_hac2b453_1
#17 190.7 Linking libtiff-4.7.0-he137b08_1
#17 190.7 Linking krb5-1.21.3-h659f571_0
#17 190.8 Linking sqlite-3.46.1-h9eae976_0
#17 190.8 Linking libblas-3.9.0-24_linux64_openblas
#17 191.8 Linking libcurl-8.10.1-hbbe4b11_0
#17 191.8 Linking libcblas-3.9.0-24_linux64_openblas
#17 192.8 Linking liblapack-3.9.0-24_linux64_openblas
#17 193.7 Linking proj-9.5.0-h12925eb_0
#17 193.8 Linking tzdata-2024b-hc8b5060_0
#17 194.0 Linking python-3.9.20-h13acc7a_1_cpython
#17 195.5 Linking wheel-0.44.0-pyhd8ed1ab_0
#17 195.9 Linking setuptools-75.1.0-pyhd8ed1ab_0
#17 196.1 Linking pip-24.2-pyh8b19718_1
#17 196.3 Linking hyperframe-6.0.1-pyhd8ed1ab_0
#17 196.3 Linking hpack-4.0.0-pyh9f0ad1d_0
#17 196.3 Linking mdurl-0.1.2-pyhd8ed1ab_0
#17 196.3 Linking pygments-2.18.0-pyhd8ed1ab_0
#17 196.8 Linking shellingham-1.5.4-pyhd8ed1ab_0
#17 196.8 Linking pycparser-2.22-pyhd8ed1ab_0
#17 196.8 Linking exceptiongroup-1.2.2-pyhd8ed1ab_0
#17 196.8 Linking six-1.16.0-pyh6c4a22f_0
#17 196.8 Linking pysocks-1.7.1-pyha2e5f31_6
#17 196.8 Linking aiohappyeyeballs-2.4.3-pyhd8ed1ab_0
#17 196.9 Linking attrs-24.2.0-pyh71513ae_0
#17 196.9 Linking python-tzdata-2024.2-pyhd8ed1ab_0
#17 197.1 Linking click-8.1.7-unix_pyh707e725_0
#17 197.1 Linking python-dotenv-1.0.1-pyhd8ed1ab_0
#17 197.2 Linking sniffio-1.3.1-pyhd8ed1ab_0
#17 197.2 Linking typing_extensions-4.12.2-pyha770c72_0
#17 197.2 Linking python-multipart-0.0.12-pyhff2d567_0
#17 197.2 Linking charset-normalizer-3.4.0-pyhd8ed1ab_0
#17 197.2 Linking idna-3.10-pyhd8ed1ab_0
#17 197.2 Linking certifi-2024.8.30-pyhd8ed1ab_0
#17 197.2 Linking pyparsing-3.2.0-pyhd8ed1ab_1
#17 197.2 Linking pytz-2024.2-pyhd8ed1ab_0
#17 197.5 Linking h2-4.1.0-pyhd8ed1ab_0
#17 197.5 Linking markdown-it-py-3.0.0-pyhd8ed1ab_0
#17 197.5 Linking python-dateutil-2.9.0-pyhd8ed1ab_0
#17 197.6 Linking dnspython-2.7.0-pyhff2d567_0
#17 197.7 Linking typer-slim-0.12.5-pyhd8ed1ab_0
#17 197.7 Linking h11-0.14.0-pyhd8ed1ab_0
#17 197.7 Linking typing-extensions-4.12.2-hd8ed1ab_0
#17 197.7 Linking anyio-4.4.0-pyhd8ed1ab_0
#17 197.7 Linking rich-13.9.2-pyhd8ed1ab_0
#17 197.8 Linking pystac-1.10.1-pyhd8ed1ab_0
#17 197.8 Linking email-validator-2.2.0-pyhd8ed1ab_0
#17 197.8 Linking annotated-types-0.7.0-pyhd8ed1ab_0
#17 197.8 Linking async-timeout-4.0.3-pyhd8ed1ab_0
#17 197.9 Linking httpcore-1.0.6-pyhd8ed1ab_0
#17 197.9 Linking starlette-0.39.2-pyhd8ed1ab_0
#17 197.9 Linking typer-slim-standard-0.12.5-hd8ed1ab_0
#17 197.9 Linking email_validator-2.2.0-hd8ed1ab_0
#17 197.9 Linking httpx-0.27.2-pyhd8ed1ab_0
#17 197.9 Linking typer-0.12.5-pyhd8ed1ab_0
#17 197.9 Linking propcache-0.2.0-py39h8cd3c5a_2
#17 198.0 Linking markupsafe-3.0.1-py39h9399b63_1
#17 198.0 Linking brotli-python-1.1.0-py39hf88036b_2
#17 198.0 Linking frozenlist-1.4.1-py39h8cd3c5a_1
#17 198.0 Linking websockets-13.1-py39h8cd3c5a_0
#17 198.0 Linking uvloop-0.20.0-py39h8cd3c5a_0
#17 198.0 Linking pyyaml-6.0.2-py39h8cd3c5a_1
#17 198.1 Linking httptools-0.6.1-py39h8cd3c5a_1
#17 198.1 Linking numpy-2.0.2-py39h9cb892a_0
#17 198.8 Linking cffi-1.17.1-py39h15c3d72_0
#17 198.9 Linking pyproj-3.6.1-py39h306d449_10
#17 199.0 Linking uvicorn-0.31.1-py39hf3d152e_0
#17 199.0 Linking multidict-6.1.0-py39h8cd3c5a_0
#17 199.0 Linking pydantic-core-2.23.4-py39he612d8f_0
#17 199.1 Linking watchfiles-0.24.0-py39he612d8f_1
#17 199.1 Linking pandas-2.2.2-py39hfc16268_1
#17 200.5 Linking shapely-2.0.6-py39hca88cd1_2
#17 200.6 Linking zstandard-0.23.0-py39h08a7858_1
#17 200.6 Linking yarl-1.15.2-py39h8cd3c5a_0
#17 200.6 Linking uvicorn-standard-0.31.1-hf3d152e_0
#17 200.6 Linking jinja2-3.1.4-pyhd8ed1ab_0
#17 200.7 Linking aiosignal-1.3.1-pyhd8ed1ab_0
#17 200.7 Linking snuggs-1.4.7-pyhd8ed1ab_1
#17 200.7 Linking pydantic-2.9.2-pyhd8ed1ab_0
#17 200.7 Linking urllib3-2.2.3-pyhd8ed1ab_0
#17 200.8 Linking fastapi-cli-0.0.5-pyhd8ed1ab_1
#17 200.8 Linking requests-2.32.3-pyhd8ed1ab_0
#17 200.8 Linking fastapi-0.115.2-pyhd8ed1ab_0
#17 200.8 Linking pystac-client-0.8.3-pyhd8ed1ab_0
#17 200.8 warning  libmamba [fastapi-0.115.2-pyhd8ed1ab_0] The following files were already present in the environment:
#17 200.8     - bin/fastapi
#17 200.9 Linking aiohttp-3.10.10-py39h9399b63_0
#17 201.7 
#17 201.7 Transaction finished
#17 201.7 
#17 201.7 To activate this environment, use:
#17 201.7 
#17 201.7     micromamba activate env_openfaas
#17 201.7 
#17 201.7 Or to execute a single command in this environment, use:
#17 201.7 
#17 201.7     micromamba run -n env_openfaas mycommand
#17 201.7 
#17 201.8 
#17 201.8 Installing pip packages: importlib-resources, --extra-index-url https://test.pypi.org/simple, assertions-toolkit
#17 204.7 Looking in indexes: https://pypi.org/simple, https://test.pypi.org/simple
#17 205.5 Collecting importlib-resources (from -r /home/app/mambafbz2DgC2W8N (line 1))
#17 205.6   Downloading importlib_resources-6.4.5-py3-none-any.whl.metadata (4.0 kB)
#17 206.1 Collecting assertions-toolkit (from -r /home/app/mambafbz2DgC2W8N (line 3))
#17 206.3   Downloading https://test-files.pythonhosted.org/packages/a8/19/f325dc3f6c5ebe9ce77f6827e196d1601851b1626c4826dc6066d5f1b1a3/assertions_toolkit-0.1.0-py3-none-any.whl.metadata (379 bytes)
#17 206.7 Collecting zipp>=3.1.0 (from importlib-resources->-r /home/app/mambafbz2DgC2W8N (line 1))
#17 206.8   Downloading zipp-3.20.2-py3-none-any.whl.metadata (3.7 kB)
#17 206.8 Downloading importlib_resources-6.4.5-py3-none-any.whl (36 kB)
#17 207.0 Downloading https://test-files.pythonhosted.org/packages/a8/19/f325dc3f6c5ebe9ce77f6827e196d1601851b1626c4826dc6066d5f1b1a3/assertions_toolkit-0.1.0-py3-none-any.whl (7.6 kB)
#17 207.0 Downloading zipp-3.20.2-py3-none-any.whl (9.2 kB)
#17 208.1 Installing collected packages: zipp, assertions-toolkit, importlib-resources
#17 208.4 Successfully installed assertions-toolkit-0.1.0 importlib-resources-6.4.5 zipp-3.20.2
#17 208.4 WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable.It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.
#17 DONE 209.7s

#18 [stage-1 10/11] RUN wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.0g-2ubuntu4_amd64.deb &&     dpkg -i libssl1.1_1.1.0g-2ubuntu4_amd64.deb
#18 0.198 --2024-10-15 08:49:34--  http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.0g-2ubuntu4_amd64.deb
#18 0.199 Resolving archive.ubuntu.com (archive.ubuntu.com)... 91.189.91.83, 91.189.91.82, 185.125.190.82, ...
#18 0.264 Connecting to archive.ubuntu.com (archive.ubuntu.com)|91.189.91.83|:80... connected.
#18 0.372 HTTP request sent, awaiting response... 200 OK
#18 0.489 Length: 1128092 (1.1M) [application/vnd.debian.binary-package]
#18 0.493 Saving to: 'libssl1.1_1.1.0g-2ubuntu4_amd64.deb'
#18 0.495 
#18 0.495      0K .......... .......... .......... .......... ..........  4%  236K 4s
#18 0.710     50K .......... .......... .......... .......... ..........  9%  444K 3s
#18 0.819    100K .......... .......... .......... .......... .......... 13%  826K 2s
#18 0.881    150K .......... .......... .......... .......... .......... 18%  936K 2s
#18 0.933    200K .......... .......... .......... .......... .......... 22% 1.43M 2s
#18 0.966    250K .......... .......... .......... .......... .......... 27% 1.82M 1s
#18 0.994    300K .......... .......... .......... .......... .......... 31% 2.03M 1s
#18 1.018    350K .......... .......... .......... .......... .......... 36% 2.31M 1s
#18 1.038    400K .......... .......... .......... .......... .......... 40% 2.53M 1s
#18 1.058    450K .......... .......... .......... .......... .......... 45% 2.79M 1s
#18 1.075    500K .......... .......... .......... .......... .......... 49% 2.79M 1s
#18 1.093    550K .......... .......... .......... .......... .......... 54% 4.33M 1s
#18 1.105    600K .......... .......... .......... .......... .......... 59% 4.20M 0s
#18 1.117    650K .......... .......... .......... .......... .......... 63% 4.30M 0s
#18 1.127    700K .......... .......... .......... .......... .......... 68% 4.77M 0s
#18 1.138    750K .......... .......... .......... .......... .......... 72% 4.93M 0s
#18 1.148    800K .......... .......... .......... .......... .......... 77% 5.69M 0s
#18 1.156    850K .......... .......... .......... .......... .......... 81% 5.62M 0s
#18 1.165    900K .......... .......... .......... .......... .......... 86% 5.32M 0s
#18 1.174    950K .......... .......... .......... .......... .......... 90% 5.43M 0s
#18 1.183   1000K .......... .......... .......... .......... .......... 95% 6.66M 0s
#18 1.190   1050K .......... .......... .......... .......... .......... 99% 6.00M 0s
#18 1.198   1100K .                                                     100% 3.23M=0.7s
#18 1.199 
#18 1.200 2024-10-15 08:49:35 (1.53 MB/s) - 'libssl1.1_1.1.0g-2ubuntu4_amd64.deb' saved [1128092/1128092]
#18 1.200 
#18 1.312 Selecting previously unselected package libssl1.1:amd64.
#18 1.321 (Reading database ... 4904 files and directories currently installed.)
#18 1.322 Preparing to unpack libssl1.1_1.1.0g-2ubuntu4_amd64.deb ...
#18 1.327 Unpacking libssl1.1:amd64 (1.1.0g-2ubuntu4) ...
#18 1.671 Setting up libssl1.1:amd64 (1.1.0g-2ubuntu4) ...
#18 2.188 debconf: unable to initialize frontend: Dialog
#18 2.188 debconf: (TERM is not set, so the dialog frontend is not usable.)
#18 2.188 debconf: falling back to frontend: Readline
#18 2.189 debconf: unable to initialize frontend: Readline
#18 2.189 debconf: (Can't locate Term/ReadLine.pm in @INC (you may need to install the Term::ReadLine module) (@INC entries checked: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.38.2 /usr/local/share/perl/5.38.2 /usr/lib/x86_64-linux-gnu/perl5/5.38 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl-base /usr/lib/x86_64-linux-gnu/perl/5.38 /usr/share/perl/5.38 /usr/local/lib/site_perl) at /usr/share/perl5/Debconf/FrontEnd/Readline.pm line 8.)
#18 2.189 debconf: falling back to frontend: Teletype
#18 2.377 Processing triggers for libc-bin (2.39-0ubuntu8.3) ...
#18 DONE 2.5s

#19 [stage-1 11/11] WORKDIR /home/app/
#19 DONE 0.0s

#20 exporting to image
#20 exporting layers
#20 exporting layers 1.6s done
#20 writing image sha256:81f8318ccbff486ab2e3af493f804266942e178316204ae6fee73dc5d6cf70f0
#20 writing image sha256:81f8318ccbff486ab2e3af493f804266942e178316204ae6fee73dc5d6cf70f0 done
#20 naming to cr.terradue.com/gep/sbas-assertion:dev done
#20 DONE 1.6s

View build details: docker-desktop://dashboard/build/desktop-linux/desktop-linux/ov4le2k9gicnk0aerg52tdqs0

 2 warnings found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
 - UndefinedVar: Usage of undefined variable '$LD_LIBRARY_PATH' (line 52)
Image: cr.terradue.com/gep/sbas-assertion:dev built.
[0] < Building sbas-assertion done in 215.65s.
[0] Worker done.

Total build time: 215.65s
```